### PR TITLE
@0x57/base32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,10 @@
 			"resolved": "packages/auth",
 			"link": true
 		},
+		"node_modules/@0x57/base32": {
+			"resolved": "packages/base32",
+			"link": true
+		},
 		"node_modules/@0x57/client": {
 			"resolved": "packages/client",
 			"link": true
@@ -112,6 +116,10 @@
 		},
 		"node_modules/@0x57/interfaces": {
 			"resolved": "packages/interfaces",
+			"link": true
+		},
+		"node_modules/@0x57/nanoid": {
+			"resolved": "packages/nanoid",
 			"link": true
 		},
 		"node_modules/@0x57/passkey": {
@@ -132,6 +140,10 @@
 		},
 		"node_modules/@0x57/typescript-config": {
 			"resolved": "packages/typescript-config",
+			"link": true
+		},
+		"node_modules/@0x57/ulid": {
+			"resolved": "packages/ulid",
 			"link": true
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -10412,6 +10424,9 @@
 			"name": "@0x57/auth",
 			"version": "0.0.0"
 		},
+		"packages/base32": {
+			"version": "0.0.0"
+		},
 		"packages/bitflag-js": {
 			"version": "1.0.0",
 			"license": "MIT",
@@ -10440,6 +10455,10 @@
 		},
 		"packages/interfaces": {
 			"name": "@0x57/interfaces",
+			"version": "0.0.0"
+		},
+		"packages/nanoid": {
+			"name": "@0x57/nanoid",
 			"version": "0.0.0"
 		},
 		"packages/passkey": {
@@ -10506,6 +10525,10 @@
 				"react": "^18.2.0",
 				"typescript": "^5.3.3"
 			}
+		},
+		"packages/ulid": {
+			"name": "@0x57/ulid",
+			"version": "0.0.0"
 		}
 	}
 }

--- a/packages/base32/.eslintrc.cjs
+++ b/packages/base32/.eslintrc.cjs
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@0x57/eslint-config/library.js"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.json",
+  },
+  ignorePatterns: [".eslintrc.cjs"],
+};

--- a/packages/base32/README.md
+++ b/packages/base32/README.md
@@ -1,0 +1,13 @@
+# base32
+
+An implementation of Crockford's base32 for encoding UInt8Array data.
+
+```ts
+import { encode, decode } from "@0x57/base32";
+
+const data = new TextEncoder().encode("Hello, World!");
+const encoded = encode(data);
+console.log(encoded); // 91JPRV3F5GG5EVVJDHJ22
+const decoded = decode(encoded);
+console.log(new TextDecoder().decode(decoded)); // Hello, World!
+```

--- a/packages/base32/package.json
+++ b/packages/base32/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@0x57/base32",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+		"clean": "rimraf dist .turbo",
+    "prettier": "prettier src/**/*.ts --check",
+		"typecheck": "tsc --noEmit",
+		"lint": "eslint . --max-warnings 0",
+		"prepublish": "npm run clean && npm run build"
+  },
+  "dependencies": {
+  }
+}

--- a/packages/base32/src/index.ts
+++ b/packages/base32/src/index.ts
@@ -1,0 +1,68 @@
+// Adapted from https://github.com/devbanana/crockford-base32/blob/develop/src/index.ts
+
+const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+export function encode(data: Uint8Array): string {
+  const input = Uint8Array.from(data); // Copy the input buffer to avoid modifying it
+  const output: number[] = [];
+  let bitsRead = 0;
+  let buffer = 0;
+
+  for (const byte of input) {
+    // Add current byte to start of buffer
+    buffer = (buffer << 8) | byte;
+    bitsRead += 8;
+
+    while (bitsRead >= 5) {
+      output.push((buffer >>> (bitsRead - 5)) & 0x1f);
+      bitsRead -= 5;
+    }
+  }
+
+  if (bitsRead > 0) {
+    output.push((buffer << (5 - bitsRead)) & 0x1f);
+  }
+
+  return output.map((byte) => alphabet.charAt(byte)).join("");
+}
+
+export function decode(data: string): Uint8Array {
+  // 1. Translate input to all uppercase
+  // 2. Translate I, L, and O to valid base 32 characters
+  // 3. Remove all hyphens
+  let input = data;
+  input = input
+    .toUpperCase()
+    .replace(/O/g, "0")
+    .replace(/[IL]/g, "1")
+    .replace(/-+/g, "");
+
+  const output: number[] = [];
+  let bitsRead = 0;
+  let buffer = 0;
+
+  for (const character of input) {
+    const byte = alphabet.indexOf(character);
+    if (byte === -1) {
+      throw new Error(
+        `Invalid base 32 character found in string: ${character}`
+      );
+    }
+
+    bitsRead += 5;
+
+    if (bitsRead >= 8) {
+      bitsRead -= 8;
+      output.push(buffer | (byte >> bitsRead));
+      buffer = (byte << (8 - bitsRead)) & 0xff;
+    } else {
+      buffer |= byte << (8 - bitsRead);
+    }
+  }
+
+  if (buffer > 0) {
+    output.push(buffer);
+  }
+
+  return Uint8Array.from(output);
+}

--- a/packages/base32/test/index.test.ts
+++ b/packages/base32/test/index.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import * as base32 from "../src";
+
+test("encode", () => {
+  const data = new TextEncoder().encode("Hello, World!");
+  const encoded = base32.encode(data);
+  expect(encoded).toBe("91JPRV3F5GG5EVVJDHJ22");
+});
+
+test("decode", () => {
+  const data = new TextEncoder().encode("Hello, World!");
+  const encoded = base32.encode(data);
+  const decoded = base32.decode(encoded);
+  expect(decoded).toEqual(data);
+});
+
+test("decode with invalid character", () => {
+  expect(() => base32.decode("91JPRV3F5GG5EVVJDHJ22!")).toThrow(
+    "Invalid base 32 character found in string: !"
+  );
+});

--- a/packages/base32/tsconfig.json
+++ b/packages/base32/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@0x57/typescript-config/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Reimplementation of `crockford-base32` that works with uint8arrays

```ts
import { encode, decode } from "@0x57/base32";

const data = new TextEncoder().encode("Hello, World!");
const encoded = encode(data);
console.log(encoded); // 91JPRV3F5GG5EVVJDHJ22
const decoded = decode(encoded);
console.log(new TextDecoder().decode(decoded)); // Hello, World!
```
